### PR TITLE
Fix the callee info update according to RETURN spec

### DIFF
--- a/bus-mapping/src/evm/opcodes/return.rs
+++ b/bus-mapping/src/evm/opcodes/return.rs
@@ -43,28 +43,28 @@ impl Opcode for Return {
                 let code = memory.0[offset..offset + length].to_vec();
                 state.code_db.insert(code);
             }
+
+            state.call_context_write(
+                &mut exec_step,
+                state.call()?.call_id,
+                CallContextField::LastCalleeId,
+                state.call()?.call_id.into(),
+            );
+
+            state.call_context_write(
+                &mut exec_step,
+                state.caller()?.call_id,
+                CallContextField::LastCalleeReturnDataOffset,
+                offset.into(),
+            );
+
+            state.call_context_write(
+                &mut exec_step,
+                state.caller()?.call_id,
+                CallContextField::LastCalleeReturnDataLength,
+                length.into(),
+            );
         }
-
-        state.call_context_write(
-            &mut exec_step,
-            state.call()?.call_id,
-            CallContextField::LastCalleeId,
-            state.call()?.call_id.into(),
-        );
-
-        state.call_context_write(
-            &mut exec_step,
-            state.caller()?.call_id,
-            CallContextField::LastCalleeReturnDataOffset,
-            offset.into(),
-        );
-
-        state.call_context_write(
-            &mut exec_step,
-            state.caller()?.call_id,
-            CallContextField::LastCalleeReturnDataLength,
-            length.into(),
-        );
 
         state.handle_return(&geth_steps[0])?;
         Ok(vec![exec_step])


### PR DESCRIPTION
According to RETURN spec, callee info update happens in restore of caller context which happens only in case C, i.e., only if it is not root call.

[RETURN spec](https://github.com/privacy-scaling-explorations/zkevm-specs/blob/master/specs/opcode/F3RETURN.md?plain=1):

The `RETURN` opcode terminates the call successfully with return data for the
caller.

It behaves differently in different scenarios:

- `is_create` and `is_root`
    - A. Returns the specified memory chunk as deployment code.
    - B. End the execution
- `is_create` and `not is_root`
    - A. Returns the specified memory chunk as deployment code.
    - C. Restores caller's context and switch to it.
- `not is_create` and `is_root`
    - B. End the execution
- `not is_create` and `not is_root`
    - D. Returns the specified memory chunk to the caller.
    - C. Restores caller's context and switch to it.

Signed-off-by: smtmfft <smtmfft@taikocha.in>